### PR TITLE
Fix linting errors around const assert vs literal type

### DIFF
--- a/src/dialog/node/node-streaming.ts
+++ b/src/dialog/node/node-streaming.ts
@@ -36,7 +36,7 @@ export default abstract class NodeStreamingDialog implements ClassicStreamingDia
     private extfilepath: string
     private GlkOte?: GlkOte
     private is_inited = false
-    streaming: true = true
+    streaming = true as const
     private userpath: string
 
     constructor() {

--- a/src/glkote/web/windows.ts
+++ b/src/glkote/web/windows.ts
@@ -320,7 +320,7 @@ const inline_alignment_classes: Record<string, string> = {
 }
 
 class BufferWindow extends TextualWindow {
-    type: 'buffer' = 'buffer'
+    type = 'buffer' as const
     innerel: JQuery<HTMLElement>
     lastline?: JQuery<HTMLElement>
     updatescrolltop = 0
@@ -460,7 +460,7 @@ class BufferWindow extends TextualWindow {
 }
 
 export class GraphicsWindow extends WindowBase {
-    type: 'graphics' = 'graphics'
+    type = 'graphics' as const
     buffer: JQuery<HTMLCanvasElement>
     canvas: JQuery<HTMLCanvasElement>
     fillcolour = ''
@@ -606,7 +606,7 @@ export class GraphicsWindow extends WindowBase {
 }
 
 class GridWindow extends TextualWindow {
-    type: 'grid' = 'grid'
+    type = 'grid' as const
     height = 0
     lines: JQuery<HTMLElement>[] = []
     width = 0


### PR DESCRIPTION
Was poking around and saw some eslint errors that were easy to fix so a bit of a drive-by pull request 😅 

The linting rule in question was [@typescript-eslint/prefer-as-const](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/prefer-as-const.md)